### PR TITLE
Major updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _build/
+_install/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ add_compile_options(-Wall -Wextra -Werror -Wconversion -pedantic)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_subdirectory("${PROJECT_SOURCE_DIR}/src")
-
-target_include_directories(hello-world-singleton PUBLIC "${PROJECT_SOURCE_DIR}/include")

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Just a fun way of overcomplicating a simple "hello world" program by using the
 
 ## Build
 
-`bash build.sh`
+`bash build.sh` or `./build.sh`
 
 ## Run
 
-`./_build/src/hello-world-singleton`
+`./_install/bin/hello-world-singleton`
 
 ## Clean
 
-`rm -rf _build/`
+`rm -rf _build/ _install/`

--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,13 @@
 
 set -euxo pipefail
 
-BUILDDIR=_build
+BUILDDIR="${PWD}/_build"
+INSTALLDIR="${PWD}/_install"
 
-mkdir -pv "${BUILDDIR}"
+rm -rf "${BUILDDIR}" "${INSTALLDIR}"
+
+mkdir -pv "${BUILDDIR}" "${INSTALLDIR}"
+
 cmake -S . -B "${BUILDDIR}"
 cmake --build "${BUILDDIR}"
+cmake --install "${BUILDDIR}" --prefix "${INSTALLDIR}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,5 @@
-add_library(helloworld STATIC hello-world.cpp)
+add_executable(hello-world-singleton hello-world.cpp main.cpp)
 
-target_include_directories(helloworld PUBLIC "${hello-world-singleton_SOURCE_DIR}/include")
+target_include_directories(hello-world-singleton PUBLIC "${hello-world-singleton_SOURCE_DIR}/include")
 
-add_executable(hello-world-singleton main.cpp)
-
-target_link_libraries(hello-world-singleton PRIVATE helloworld)
+install(TARGETS hello-world-singleton DESTINATION bin)


### PR DESCRIPTION
- Top-level CMakeLists.txt:
   - add option to disable CMAKE_CXX_EXTENSIONS (c++11 instead of g++11)
   - remove useless line

- CMakeLists.txt at src/:
   - simplify by not building an intermediate static lib
   - add install() command

- build.sh script:
   - updates to "install" to a local, designed dir (no need to locate the compiled binary executable at build dir)

- .gitignore:
    - update to ignore the new '_install' dir

- README.md: - update path to run the resulting executable from the new dir